### PR TITLE
Add dual HalfLife variants with Google Sheets logging

### DIFF
--- a/DeJargonizer2025/DeJargonizer2025/DeJargonizer2025.csproj
+++ b/DeJargonizer2025/DeJargonizer2025/DeJargonizer2025.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="Google.Apis" Version="1.65.0.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.65.0" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.65.0.3765" />
     <PackageReference Include="DocX" Version="4.0.25105.5786" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.Office.Interop.Word" Version="15.0.4797.1004" />

--- a/DeJargonizer2025/DeJargonizer2025/Program.cs
+++ b/DeJargonizer2025/DeJargonizer2025/Program.cs
@@ -23,6 +23,7 @@ try
 
     builder.Services.AddSingleton<UsageCounter>();
     builder.Services.AddSingleton<GPTApiClient>();
+    builder.Services.AddSingleton<GoogleSheetsService>();
 
     var supabaseClient = new SupabaseClient();
     supabaseClient.Init().GetAwaiter().GetResult();

--- a/DeJargonizer2025/DeJargonizer2025/Services/GoogleSheetsService.cs
+++ b/DeJargonizer2025/DeJargonizer2025/Services/GoogleSheetsService.cs
@@ -1,0 +1,100 @@
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Services;
+using Google.Apis.Sheets.v4;
+using Google.Apis.Sheets.v4.Data;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace JargonProject.Services;
+
+public class GoogleSheetsService
+{
+    private readonly ILogger<GoogleSheetsService> _logger;
+    private readonly Lazy<SheetsService?> _sheetsService;
+    private readonly string? _spreadsheetId;
+    private readonly string _applicationName;
+
+    public GoogleSheetsService(ILogger<GoogleSheetsService> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+        _spreadsheetId = Environment.GetEnvironmentVariable("HALFLIFE_SPREADSHEET_ID")
+                         ?? configuration["GoogleSheets:SpreadsheetId"];
+        _applicationName = configuration["GoogleSheets:ApplicationName"] ?? "DeJargonizer HalfLife";
+
+        var credentialPath = Environment.GetEnvironmentVariable("HALFLIFE_GOOGLE_CREDENTIALS_PATH")
+                             ?? configuration["GoogleSheets:CredentialsPath"]
+                             ?? Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+
+        _sheetsService = new Lazy<SheetsService?>(() =>
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(_spreadsheetId))
+                {
+                    _logger.LogWarning("Google Sheets spreadsheet id is not configured. Skipping initialization.");
+                    return null;
+                }
+
+                GoogleCredential credential;
+
+                if (!string.IsNullOrWhiteSpace(credentialPath))
+                {
+                    credential = GoogleCredential.FromFile(credentialPath)
+                        .CreateScoped(SheetsService.Scope.Spreadsheets);
+                }
+                else
+                {
+                    credential = GoogleCredential.GetApplicationDefault()
+                        .CreateScoped(SheetsService.Scope.Spreadsheets);
+                }
+
+                return new SheetsService(new BaseClientService.Initializer
+                {
+                    HttpClientInitializer = credential,
+                    ApplicationName = _applicationName,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to initialize Google Sheets service");
+                return null;
+            }
+        });
+    }
+
+    public async Task AppendRowAsync(string sheetName, IList<object> values, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(sheetName))
+        {
+            _logger.LogWarning("Sheet name not provided. Skipping Google Sheets append.");
+            return;
+        }
+
+        var service = _sheetsService.Value;
+
+        if (service == null || string.IsNullOrWhiteSpace(_spreadsheetId))
+        {
+            _logger.LogWarning("Google Sheets service is not available. Row will not be written.");
+            return;
+        }
+
+        try
+        {
+            var range = $"{sheetName}!A:Z";
+            var valueRange = new ValueRange
+            {
+                Values = new List<IList<object>> { values }
+            };
+
+            var appendRequest = service.Spreadsheets.Values.Append(valueRange, _spreadsheetId, range);
+            appendRequest.ValueInputOption = SpreadsheetsResource.ValuesResource.AppendRequest.ValueInputOptionEnum.USERENTERED;
+            appendRequest.InsertDataOption = SpreadsheetsResource.ValuesResource.AppendRequest.InsertDataOptionEnum.INSERTROWS;
+
+            await appendRequest.ExecuteAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to append row to Google Sheets");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture a participant name at the beginning of the HalfLife conversation and branch the flow for feedback or no-feedback runs
- persist conversation outcomes to Supabase and variant-specific Google Sheets tabs using a reusable sheets client
- register the new sheets service and dependencies needed for Google Sheets API access

## Testing
- `dotnet build` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efae8af0b8832182130a1d08a13b38